### PR TITLE
Update procedures to be in DB namespace

### DIFF
--- a/modules/ROOT/pages/changelog.adoc
+++ b/modules/ROOT/pages/changelog.adoc
@@ -3,6 +3,24 @@
 This page lists changes to the Change Data Capture feature in different versions of Neo4j.
 
 == Version 5.17
+=== New features
+[cols="2", options="header"]
+|===
+| Feature
+| Details
+
+a|
+label:functionality[]
+label:new[]
+
+Procedures names have moved into database namespace
+a|
+The procedure names have been updated as follows:
+
+ - *cdc.earliest* becomes *db.cdc.earliest*
+ - *cdc.current* becomes *db.cdc.current*
+ - *cdc.query* becomes *db.cdc.query*
+|===
 === Bug fixes
 [cols="2", options="header"]
 |===

--- a/modules/ROOT/pages/examples/csharp.adoc
+++ b/modules/ROOT/pages/examples/csharp.adoc
@@ -46,7 +46,7 @@ static class Program
             await session.ExecuteReadAsync(async tx =>
             {
                 var from = _from;
-                var result = await tx.RunAsync("CALL cdc.query($from, $selectors)", new
+                var result = await tx.RunAsync("CALL db.cdc.query($from, $selectors)", new
                 {
                     from,
                     selectors = _selectors,
@@ -74,7 +74,7 @@ static class Program
         private async Task<string> EarliestChangeId() // <5>
         {
             var response = await _driver
-                .ExecutableQuery("CALL cdc.earliest")
+                .ExecutableQuery("CALL db.cdc.earliest")
                 .WithMap(record => record["id"].As<string>())
                 .ExecuteAsync();
 
@@ -84,7 +84,7 @@ static class Program
         private async Task<string> CurrentChangeId() // <6>
         {
             var response = await _driver
-                .ExecutableQuery("CALL cdc.current")
+                .ExecutableQuery("CALL db.cdc.current")
                 .WithMap(record => record["id"].As<string>())
                 .ExecuteAsync();
 

--- a/modules/ROOT/pages/examples/go.adoc
+++ b/modules/ROOT/pages/examples/go.adoc
@@ -71,7 +71,7 @@ func (s *CDCService) queryChanges(ctx context.Context) error { // <2>
     session := s.driver.NewSession(ctx, neo4j.SessionConfig{DatabaseName: s.database})
 
     _, err := session.ExecuteRead(ctx, func(tx neo4j.ManagedTransaction) (any, error) {
-        result, err := tx.Run(ctx, "CALL cdc.query($from, $selectors)", map[string]any{
+        result, err := tx.Run(ctx, "CALL db.cdc.query($from, $selectors)", map[string]any{
             "from":      s.from(),
             "selectors": s.selectors,
         })
@@ -103,11 +103,11 @@ func (s *CDCService) queryChanges(ctx context.Context) error { // <2>
 }
 
 func (s *CDCService) earliestChangeID(ctx context.Context) (string, error) { // <5>
-    return queryChangeID(ctx, s.driver, s.database, "CALL cdc.earliest()")
+    return queryChangeID(ctx, s.driver, s.database, "CALL db.cdc.earliest()")
 }
 
 func (s *CDCService) currentChangeID(ctx context.Context) (string, error) { // <6>
-    return queryChangeID(ctx, s.driver, s.database, "CALL cdc.current()")
+    return queryChangeID(ctx, s.driver, s.database, "CALL db.cdc.current()")
 }
 
 func (s *CDCService) from() string {

--- a/modules/ROOT/pages/examples/java.adoc
+++ b/modules/ROOT/pages/examples/java.adoc
@@ -53,7 +53,7 @@ class CDCService implements Closeable {
     private synchronized void queryChanges() { // <2>
         try (var session = driver.session(SessionConfig.forDatabase(database))) {
             session.executeRead(tx -> {
-                var result = tx.run(new Query("CALL cdc.query($from, $selectors)", Map.of("from", cursor, "selectors", selectors)));
+                var result = tx.run(new Query("CALL db.cdc.query($from, $selectors)", Map.of("from", cursor, "selectors", selectors)));
                 while (result.hasNext()) {
                     var change = result.next();
                     applyChange(change); // <3>
@@ -69,7 +69,7 @@ class CDCService implements Closeable {
     private String earliestChangeID() { // <5>
         try (var session = driver.session(SessionConfig.forDatabase(database))) {
             return session.executeRead(tx -> {
-                var result = tx.run(new Query("CALL cdc.earliest"));
+                var result = tx.run(new Query("CALL db.cdc.earliest"));
                 return result.single().get("id").asString();
             });
         }
@@ -78,7 +78,7 @@ class CDCService implements Closeable {
     private String currentChangeID() { // <6>
         try (var session = driver.session(SessionConfig.forDatabase(database))) {
             return session.executeRead(tx -> {
-                var result = tx.run(new Query("CALL cdc.current"));
+                var result = tx.run(new Query("CALL db.cdc.current"));
                 return result.single().get("id").asString();
             });
         }

--- a/modules/ROOT/pages/examples/js.adoc
+++ b/modules/ROOT/pages/examples/js.adoc
@@ -17,7 +17,7 @@ async function queryChanges(driver, database, cursor, selectors) {
   const session = driver.session({database: database});
   try {
     await session.executeRead((tx) => {
-      return tx.run('CALL cdc.query($from, $selectors)',
+      return tx.run('CALL db.cdc.query($from, $selectors)',
           {from: cursor, selectors: selectors}); // <2>
     })
         .then((res) => {
@@ -42,14 +42,14 @@ function queryChangesLoop(driver, database, cursor, selectors) {
 }
 
 function earliestChangeId(driver, database) { // <5>
-  return driver.executeQuery('CALL cdc.earliest', {}, {database: database})
+  return driver.executeQuery('CALL db.cdc.earliest', {}, {database: database})
       .then((res) => {
         return res.records[0].get('id');
       });
 }
 
 function currentChangeId(driver, database) { // <6>
-  return driver.executeQuery('CALL cdc.current', {}, {'database': database})
+  return driver.executeQuery('CALL db.cdc.current', {}, {'database': database})
       .then((res) => {
         return res.records[0].get('id');
       });
@@ -83,7 +83,7 @@ main();
 <1> This method is called once for each change event. It should be replaced depending on your use case.
 <2> This query fetches the changes from the database.
 <3> Here we call a method once for each change.
-<4> Note that we update the cursor defined outside the anonymous function. `session.executeRead` might re-try the query, re-running the inner anonymous function. In order to avoid re-trying from an already applied cursor position, we need to ensure that further calls to `cdc.query` are executed with the new cursor value.
+<4> Note that we update the cursor defined outside the anonymous function. `session.executeRead` might re-try the query, re-running the inner anonymous function. In order to avoid re-trying from an already applied cursor position, we need to ensure that further calls to `db.cdc.query` are executed with the new cursor value.
 <5> Use this function to get the earliest available change id.
 <6> Use this function to get the current change id.
 <7> Here you can limit the returned changes. The out-commented line would select only node changes and exclude all relationship changes.

--- a/modules/ROOT/pages/examples/python.adoc
+++ b/modules/ROOT/pages/examples/python.adoc
@@ -28,7 +28,7 @@ class CDCService:
         print(json.dumps(record_dict, indent=2, default=repr))
 
     def query_changes_query(self, tx):
-        result = tx.run('CALL cdc.query($cursor, $selectors)', # <2>
+        result = tx.run('CALL db.cdc.query($cursor, $selectors)', # <2>
                         cursor=self.cursor, selectors=self.selectors)
         for record in result:
             try:
@@ -44,12 +44,12 @@ class CDCService:
 
     def earliest_change_id(self): # <5>
         records, _, _ = self.driver.execute_query(
-            'CALL cdc.earliest', database_=self.database)
+            'CALL db.cdc.earliest', database_=self.database)
         return records[0]['id']
 
     def current_change_id(self): # <6>
         records, _, _ = self.driver.execute_query(
-            'CALL cdc.current', database_=self.database)
+            'CALL db.cdc.current', database_=self.database)
         return records[0]['id']
 
     def run(self):

--- a/modules/ROOT/pages/getting-started/enrichment-mode.adoc
+++ b/modules/ROOT/pages/getting-started/enrichment-mode.adoc
@@ -83,8 +83,8 @@ Regular change identifiers generated before this point can no longer be used.
 Even if enrichment is re-enabled, the previously generated change identifiers remain invalid.
 
 After re-enabling enrichment, using outdated identifiers will lead to exceptions or inconsistent results.
-The xref:procedures/current.adoc[cdc.current] or xref:procedures/earliest.adoc[cdc.earliest] procedures should be used to acquire a new starting point.
+The xref:procedures/current.adoc[db.cdc.current] or xref:procedures/earliest.adoc[db.cdc.earliest] procedures should be used to acquire a new starting point.
 
-Note that the identifiers returned by xref:procedures/earliest.adoc[cdc.earliest] has a special behaviour.
+Note that the identifiers returned by xref:procedures/earliest.adoc[db.cdc.earliest] has a special behaviour.
 The generated earliest change identifier will always point to the earliest transaction log entry that contains change data capture information, up to the latest time when enrichment was enabled.
 ====

--- a/modules/ROOT/pages/getting-started/security.adoc
+++ b/modules/ROOT/pages/getting-started/security.adoc
@@ -3,13 +3,13 @@
 :description: Security considerations when using CDC.
 
 CDC returns all changes in the database and is not limited to the entities which a certain user is allowed to access.
-In order to prevent unauthorized access, the procedure xref:procedures/query.adoc[`cdc.query`] requires admin privileges and should be configured for least privilege access.
+In order to prevent unauthorized access, the procedure xref:procedures/query.adoc[`db.cdc.query`] requires admin privileges and should be configured for least privilege access.
 
-For a regular user to be able to run `cdc.query`, the user must have been granted execute privileges as well as boosted execute privileges.
+For a regular user to be able to run `db.cdc.query`, the user must have been granted execute privileges as well as boosted execute privileges.
 [source, cypher]
 ----
-GRANT EXECUTE PROCEDURE cdc.query ON DBMS TO $role
-GRANT EXECUTE BOOSTED PROCEDURE cdc.query ON DBMS TO $role
+GRANT EXECUTE PROCEDURE db.cdc.query ON DBMS TO $role
+GRANT EXECUTE BOOSTED PROCEDURE db.cdc.query ON DBMS TO $role
 ----
 
 [NOTE]
@@ -27,6 +27,6 @@ GRANT ACCESS ON DATABASE $database TO $role
 Usually The `PUBLIC` role already has access to the default database.
 ====
 
-The procedures xref:procedures/current.adoc[cdc.current] and xref:procedures/earliest.adoc[cdc.earliest] do not require admin privileges. In order to execute these, access to the database and regular execution privileges are sufficient.
+The procedures xref:procedures/current.adoc[db.cdc.current] and xref:procedures/earliest.adoc[db.cdc.earliest] do not require admin privileges. In order to execute these, access to the database and regular execution privileges are sufficient.
 
 For more details regarding procedure privileges in Neo4j, see link:{neo4j-docs-base-uri}/operations-manual/{page-version}/authentication-authorization/manage-execute-permissions[Operations Manual -> Manage procedure and user-defined function permissions].

--- a/modules/ROOT/pages/procedures/current.adoc
+++ b/modules/ROOT/pages/procedures/current.adoc
@@ -1,13 +1,13 @@
 [[current]]
 = Acquiring the current change identifier
 
-The procedure `cdc.current` is used to acquire a change identifier for the last committed transaction.
+The procedure `db.cdc.current` is used to acquire a change identifier for the last committed transaction.
 Note that the returned identifier is exclusive, and does not include the changes that happened in the transaction it points to.
 
 .Signature
 [source]
 ----
-cdc.current() :: (
+db.cdc.current() :: (
     id :: STRING? // <1>
 )
 ----
@@ -24,7 +24,7 @@ You should consider this when restoring a database from a backup, since the rest
 .Query current change identifier
 [source, cypher]
 ----
-CALL cdc.current()
+CALL db.cdc.current()
 ----
 
 .Result

--- a/modules/ROOT/pages/procedures/earliest.adoc
+++ b/modules/ROOT/pages/procedures/earliest.adoc
@@ -1,19 +1,19 @@
 [[earliest]]
 = Acquiring the earliest change identifier
 
-The procedure `cdc.earliest` is used to acquire a change identifier for the earliest available change.
+The procedure `db.cdc.earliest` is used to acquire a change identifier for the earliest available change.
 
 .Signature
 [source]
 ----
-cdc.earliest() :: (
+db.cdc.earliest() :: (
     id :: STRING? // <1>
 )
 ----
 
 <1> A change identifier that refers to the earliest change available.
 
-Unlike change identifiers returned from `cdc.query` or `cdc.current`, this identifier does not refer to a specific change.
+Unlike change identifiers returned from `db.cdc.query` or `db.cdc.current`, this identifier does not refer to a specific change.
 Instead, it dynamically points to the earliest transaction log entry that contains change data capture information, up to the latest time when enrichment was enabled.
 
 [WARNING]
@@ -26,7 +26,7 @@ You should consider this when restoring a database from a backup, since the rest
 .Query earliest change identifier
 [source, cypher]
 ----
-CALL cdc.earliest()
+CALL db.cdc.earliest()
 ----
 
 .Result

--- a/modules/ROOT/pages/procedures/query.adoc
+++ b/modules/ROOT/pages/procedures/query.adoc
@@ -1,7 +1,7 @@
 [[change-data-capture-querying-changes]]
 = Querying changes
 
-The procedure `cdc.query` is used to query the database for captured changes.
+The procedure `db.cdc.query` is used to query the database for captured changes.
 Once all changes have been streamed the query terminates.
 
 [NOTE]
@@ -16,7 +16,7 @@ Even if enabled again, it is not possible to query the previous change records.
 .Signature
 [source]
 ----
-cdc.query(
+db.cdc.query(
     from =  :: STRING?, // <1>
     selectors = [] :: LIST? OF MAP? // <2>
 ) :: (
@@ -28,10 +28,10 @@ cdc.query(
 ) 
 ----
 
-<1> The change identifier, either captured from an earlier call to `cdc.query` or from one of `cdc.current` or `cdc.earliest`, to query the captured changes from.
-Default value is `""` (empty string) which is replaced with `cdc.current` implicitly.
+<1> The change identifier, either captured from an earlier call to `db.cdc.query` or from one of `db.cdc.current` or `db.cdc.earliest`, to query the captured changes from.
+Default value is `""` (empty string) which is replaced with `db.cdc.current` implicitly.
 This value is treated as exclusive and the results of the query do not include the change corresponding to this value.
-To get a `from` value for the first iteration, see xref:procedures/current.adoc[cdc.current] and xref:procedures/earliest.adoc[cdc.earliest].
+To get a `from` value for the first iteration, see xref:procedures/current.adoc[db.cdc.current] and xref:procedures/earliest.adoc[db.cdc.earliest].
 <2> An optional list of selectors that could be used to filter out changes.
 Default is an empty list, which means _all_ changes are returned without any filtering taking place.
 See xref:selectors/index.adoc[selectors] for details.
@@ -52,7 +52,7 @@ For a detailed description of change event, see xref:procedures/output-schema.ad
 .Query for changes
 [source, cypher]
 ----
-CALL cdc.query("A3V16ZaLlUmnipHLFkWrlA0AAAAAAAAABAAAAAAAAAAA")
+CALL db.cdc.query("A3V16ZaLlUmnipHLFkWrlA0AAAAAAAAABAAAAAAAAAAA")
 ----
 
 .Result

--- a/modules/ROOT/pages/selectors/examples.adoc
+++ b/modules/ROOT/pages/selectors/examples.adoc
@@ -12,7 +12,7 @@ Changes can be filtered to only return creates, updates or deletes, regardless o
 .Query
 [source, cypher]
 ----
-CALL cdc.query($previousChangeId, [{
+CALL db.cdc.query($previousChangeId, [{
     select: "e", 
     operation: "c"
 }])
@@ -25,7 +25,7 @@ Note that if a list of properties is provided, for the change to be selected, al
 .Query entities where a specific property is changed
 [source, cypher]
 ----
-CALL cdc.query($previousChangeId, [{
+CALL db.cdc.query($previousChangeId, [{
     select: "e",
     changesTo: ["name"]
 }])
@@ -34,7 +34,7 @@ CALL cdc.query($previousChangeId, [{
 .Query nodes where a specific property is changed
 [source, cypher]
 ----
-CALL cdc.query($previousChangeId, [{
+CALL db.cdc.query($previousChangeId, [{
     select: "n",
     changesTo: ["name"]
 }])
@@ -43,7 +43,7 @@ CALL cdc.query($previousChangeId, [{
 .Query relationships where a specific property is changed
 [source, cypher]
 ----
-CALL cdc.query($previousChangeId, [{
+CALL db.cdc.query($previousChangeId, [{
     select: "r",
     changesTo: ["registerId"]
 }])
@@ -55,7 +55,7 @@ Changes can be filtered to only include those where the transaction was carried 
 .Query entities changed by a particular user
 [source, cypher]
 ----
-CALL cdc.query($previousChangeId, [{
+CALL db.cdc.query($previousChangeId, [{
     select: "e",
     executingUser: "alice"
 }])
@@ -64,7 +64,7 @@ CALL cdc.query($previousChangeId, [{
 .Query nodes changed by a user impersonating another
 [source, cypher]
 ----
-CALL cdc.query($previousChangeId, [{
+CALL db.cdc.query($previousChangeId, [{
     select: "n",
     authenticatedUser: "alice",
     executingUser: "bob"
@@ -74,7 +74,7 @@ CALL cdc.query($previousChangeId, [{
 .Query relationships changed when a specific metadata property was set on the transaction
 [source, cypher]
 ----
-CALL cdc.query($previousChangeId, [{
+CALL db.cdc.query($previousChangeId, [{
     select: "r",
     txMetadata: {
         correlationId: 123456789
@@ -90,7 +90,7 @@ See link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/functions/scalar/#fu
 .Query node changes
 [source, cypher]
 ----
-CALL cdc.query($previousChangeId, [{
+CALL db.cdc.query($previousChangeId, [{
     select: "n",
     elementId: "4:e239be76-c7e8-43d8-aa03-567de592f426:0"
 }])
@@ -99,7 +99,7 @@ CALL cdc.query($previousChangeId, [{
 .Query relationship changes
 [source, cypher]
 ----
-CALL cdc.query($previousChangeId, [{
+CALL db.cdc.query($previousChangeId, [{
     select: "r",
     elementId: "5:a439fca3-d8b3-35f0-aa49-987fa112f993:0"
 }])
@@ -113,7 +113,7 @@ See xref:getting-started/constraints.adoc[] for details.
 .Query node changes by key
 [source, cypher]
 ----
-CALL cdc.query($previousChangeId, [{
+CALL db.cdc.query($previousChangeId, [{
     select: "n", 
     key: {
         name: "Kevin", 
@@ -125,7 +125,7 @@ CALL cdc.query($previousChangeId, [{
 .Query relationship changes by key
 [source, cypher]
 ----
-CALL cdc.query($previousChangeId, [{
+CALL db.cdc.query($previousChangeId, [{
     select: "r", 
     key: {
         registerId: 1001
@@ -144,7 +144,7 @@ Node changes can be filtered to specific labels.
 .Query
 [source, cypher]
 ----
-CALL cdc.query($previousChangeId, [{
+CALL db.cdc.query($previousChangeId, [{
     select: "n", 
     labels: ["Person", "Actor"]
 }])
@@ -163,7 +163,7 @@ Relationship changes can be filtered to a specific type.
 .Query
 [source, cypher]
 ----
-CALL cdc.query($previousChangeId, [{
+CALL db.cdc.query($previousChangeId, [{
     select: "r", 
     type: "ACTED_IN"
 }])
@@ -175,7 +175,7 @@ Relationship changes can be selected based on their start and end nodes.
 .Query relationships that has a start node with a specific label
 [source, cypher]
 ----
-CALL cdc.query($previousChangeId, [{
+CALL db.cdc.query($previousChangeId, [{
     select: "r",
     start: {
         labels: ["Person"]
@@ -186,7 +186,7 @@ CALL cdc.query($previousChangeId, [{
 .Query relationships that is between specific labels
 [source, cypher, role="nocollapse"]
 ----
-CALL cdc.query($previousChangeId, [{
+CALL db.cdc.query($previousChangeId, [{
     select: "r",
     start: {
         labels: ["Person"]
@@ -200,7 +200,7 @@ CALL cdc.query($previousChangeId, [{
 .Query relationships that is between specific labels and with a specific type
 [source, cypher, role="nocollapse"]
 ----
-CALL cdc.query($previousChangeId, [{
+CALL db.cdc.query($previousChangeId, [{
     select: "r",
     type: "ACTED_IN",
     start: {
@@ -215,7 +215,7 @@ CALL cdc.query($previousChangeId, [{
 .Query relationships that involves a specific node
 [source, cypher, role="nocollapse"]
 ----
-CALL cdc.query($previousChangeId, [{
+CALL db.cdc.query($previousChangeId, [{
     select: "r",
     start: {
         labels: ["Person"],
@@ -239,7 +239,7 @@ CALL cdc.query($previousChangeId, [{
 .Query nodes and relationships of specific labels and types
 [source, cypher, role="nocollapse"]
 ----
-CALL cdc.query($previousChangeId, [{
+CALL db.cdc.query($previousChangeId, [{
     select: "n",
     labels: ["Person"]
 }, {

--- a/modules/ROOT/pages/selectors/index.adoc
+++ b/modules/ROOT/pages/selectors/index.adoc
@@ -2,7 +2,7 @@
 = Selectors
 :description: This chapter describes how to filter captured change data.
 
-`cdc.query` procedure support filtering returned changes using user provided selectors.
+`db.cdc.query` procedure support filtering returned changes using user provided selectors.
 
 == Selector schema
 
@@ -158,7 +158,7 @@ For example, specifying both `name` and `surname` as a `changesTo` value only re
 .Query changes updating both `name` and `surname` properties
 [source, cypher]
 ----
-CALL cdc.query($previousChangeId, [{select:"n", changesTo:["name", "surname"]}])
+CALL db.cdc.query($previousChangeId, [{select:"n", changesTo:["name", "surname"]}])
 ----
 
 In order to extract changes for either `name` *or* `surname` properties, two separate selectors have to be specified:
@@ -166,7 +166,7 @@ In order to extract changes for either `name` *or* `surname` properties, two sep
 .Query changes updating either `name` or `surname` properties
 [source, cypher]
 ----
-CALL cdc.query($previousChangeId, [
+CALL db.cdc.query($previousChangeId, [
     {select:"n", changesTo:["name"]},
     {select:"n", changesTo:["surname"]}
 ])

--- a/modules/ROOT/pages/troubleshooting.adoc
+++ b/modules/ROOT/pages/troubleshooting.adoc
@@ -20,4 +20,4 @@ Please review your settings and increase the log retention period to fit your re
 === Neo.ClientError.ChangeDataCapture.InvalidIdentifier
 
 The change identifier provided is either invalid or generated for another database.
-Verify that the change identifier you've provided is acquired from either of xref:procedures/earliest.adoc[cdc.earliest], xref:procedures/current.adoc[cdc.current] or xref:procedures/query.adoc[cdc.query] procedures for this database.
+Verify that the change identifier you've provided is acquired from either of xref:procedures/earliest.adoc[db.cdc.earliest], xref:procedures/current.adoc[db.cdc.current] or xref:procedures/query.adoc[db.cdc.query] procedures for this database.


### PR DESCRIPTION
Documents the changes from https://github.com/neo-technology/neo4j/pull/24050

Kept the previous naming in the changelog page for an older version entry - wasn't sure if that should be updated too