### PR TITLE
Examples to call db.cdc.current before db.cdc.query (#40)

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,6 +1,15 @@
 = Documentation Template
 
-This repo contains the files that you need to start a new Neo4j documentation project.
+This repo contains the files that you need to work with the CDC docs.
+There are two branches: `main` and `dev`.
+`main` reflects the current docs and `dev` should reflect the current docs plus any work to go in to the next release.
+All PRs should be raised against `dev` and if applicable, cherry-picked to `main`.
+Merged PRs against `main` are published automatically.
+
+The examples in this repo have a separate repo with executable variants:
+https://github.com/neo-technology/cdc-documentation-examples
+
+Upon release of a minor version, the `dev` branch is merged into the `main` branch.
 
 == Prereqs
 

--- a/modules/ROOT/pages/examples/csharp.adoc
+++ b/modules/ROOT/pages/examples/csharp.adoc
@@ -42,7 +42,7 @@ static class Program
         private async Task QueryChanges(CancellationToken cancellation) // <2>
         {
             await using var session = _driver.AsyncSession(ConfigureSession(_database));
-
+            var current = await CurrentChangeId();
             await session.ExecuteReadAsync(async tx =>
             {
                 var from = _from;
@@ -52,10 +52,17 @@ static class Program
                     selectors = _selectors,
                 });
 
+                var processed = 0;
                 await foreach (var record in result.WithCancellation(cancellation))
                 {
                     ApplyChange(record); // <3>
                     _from = record["id"].As<string>(); // <4>
+                    processed++;
+                }
+
+                if (processed == 0)
+                {
+                    _from = current; // <5>
                 }
             });
         }
@@ -71,7 +78,7 @@ static class Program
             };
         }
 
-        private async Task<string> EarliestChangeId() // <5>
+        private async Task<string> EarliestChangeId() // <6>
         {
             var response = await _driver
                 .ExecutableQuery("CALL db.cdc.earliest")
@@ -81,7 +88,7 @@ static class Program
             return response.Result[0];
         }
 
-        private async Task<string> CurrentChangeId() // <6>
+        private async Task<string> CurrentChangeId() // <7>
         {
             var response = await _driver
                 .ExecutableQuery("CALL db.cdc.current")
@@ -107,7 +114,7 @@ static class Program
                     {
                         await QueryChanges(cancellation);
 
-                        await Task.Delay(TimeSpan.FromMilliseconds(500), cancellation); // <7>
+                        await Task.Delay(TimeSpan.FromMilliseconds(500), cancellation); // <8>
                     }
                 }
                 finally
@@ -167,7 +174,7 @@ static class Program
         {
             var selectors = new List<object>
             {
-                // new // <8>
+                // new // <9>
                 // {
                 //     select = "n", labels = new[] { "Person", "Employee" }
                 // },
@@ -191,9 +198,15 @@ static class Program
 
 <1> This method is called once for each change event. It should be replaced based on your use case.
 <2> This method fetches the changes from the database.
-<3> Here we call a method once for each change.
-<4> Note that `ExecuteReadAsync` may retry failing queries. In order to avoid seeing the same change twice, we update the cursor as we apply the changes.
-<5> Use this function to get the earliest available change id.
-<6> Use this function to get the current change id.
-<7> Here we wait for 500 milliseconds so that `QueryChanges` gets called repeatedly.
-<8> Here you can use a filter to receive only the changes you are interested in. The out-commented line would select only node changes that has both `Person` and `Employee` labels.
+<3> This method is called once for each change.
+<4> Note that `ExecuteReadAsync` may retry failing queries.
+To avoid seeing the same change twice, update the cursor as the changes are applied.
+
+<5> The cursor is moved forward to keep it up-to-date.
+This may not be necessary in your use case. 
+See xref:getting-started/key-considerations.adoc#cursor-management[Cursor Management] for details.
+<6> Use this function to get the earliest available change id.
+<7> Use this function to get the current change id.
+<8> Wait for 500 milliseconds so that `QueryChanges` gets called repeatedly.
+<9> The results may be filtered to return a subset of changes.
+The out-commented line would select only node changes that have both `Person` and `Employee` labels.

--- a/modules/ROOT/pages/examples/go.adoc
+++ b/modules/ROOT/pages/examples/go.adoc
@@ -5,225 +5,239 @@
 package main
 
 import (
-    "context"
-    "encoding/json"
-    "fmt"
-    "log"
-    "os"
-    "os/signal"
-    "sync"
-    "sync/atomic"
-    "time"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"os/signal"
+	"sync"
+	"sync/atomic"
+	"time"
 
-    "github.com/neo4j/neo4j-go-driver/v5/neo4j"
-    "github.com/spf13/cobra"
-    "github.com/tidwall/pretty"
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
+	"github.com/spf13/cobra"
+	"github.com/tidwall/pretty"
 )
 
 func applyChange(record *neo4j.Record) error { // <1>
-    jsonOutput, err := json.Marshal(asMap(record))
-    if err != nil {
-        return fmt.Errorf("unable to jsonify record: %w", err)
-    }
+	jsonOutput, err := json.Marshal(asMap(record))
+	if err != nil {
+		return fmt.Errorf("unable to jsonify record: %w", err)
+	}
 
-    fmt.Println(string(pretty.Color(pretty.Pretty(jsonOutput), pretty.TerminalStyle)))
+	fmt.Println(string(pretty.Color(pretty.Pretty(jsonOutput), pretty.TerminalStyle)))
 
-    return nil
+	return nil
 }
 
 func queryChangeID(ctx context.Context, driver neo4j.DriverWithContext, database string, query string) (string, error) {
-    result, err := neo4j.ExecuteQuery(ctx, driver, query, nil, neo4j.EagerResultTransformer, neo4j.ExecuteQueryWithDatabase(database), neo4j.ExecuteQueryWithReadersRouting())
-    if err != nil {
-        return "", fmt.Errorf("unable to query change identifier: %w", err)
-    }
+	result, err := neo4j.ExecuteQuery(ctx, driver, query, nil, neo4j.EagerResultTransformer, neo4j.ExecuteQueryWithDatabase(database), neo4j.ExecuteQueryWithReadersRouting())
+	if err != nil {
+		return "", fmt.Errorf("unable to query change identifier: %w", err)
+	}
 
-    if len(result.Records) != 1 {
-        return "", fmt.Errorf("expected one record, but got %d", len(result.Records))
-    }
+	if len(result.Records) != 1 {
+		return "", fmt.Errorf("expected one record, but got %d", len(result.Records))
+	}
 
-    id, _, err := neo4j.GetRecordValue[string](result.Records[0], "id")
-    if err != nil {
-        return "", fmt.Errorf("unable to extract id: %w", err)
-    }
+	id, _, err := neo4j.GetRecordValue[string](result.Records[0], "id")
+	if err != nil {
+		return "", fmt.Errorf("unable to extract id: %w", err)
+	}
 
-    return id, nil
+	return id, nil
 }
 
 func asMap(record *neo4j.Record) map[string]any {
-    result := make(map[string]any, len(record.Keys))
+	result := make(map[string]any, len(record.Keys))
 
-    for i := 0; i < len(record.Keys); i++ {
-        result[record.Keys[i]] = record.Values[i]
-    }
+	for i := 0; i < len(record.Keys); i++ {
+		result[record.Keys[i]] = record.Values[i]
+	}
 
-    return result
+	return result
 }
 
 type CDCService struct {
-    driver    neo4j.DriverWithContext
-    database  string
-    waitGroup sync.WaitGroup
-    cursor    atomic.Pointer[string]
-    selectors []any
+	driver    neo4j.DriverWithContext
+	database  string
+	waitGroup sync.WaitGroup
+	cursor    atomic.Pointer[string]
+	selectors []any
 }
 
 func (s *CDCService) queryChanges(ctx context.Context) error { // <2>
-    session := s.driver.NewSession(ctx, neo4j.SessionConfig{DatabaseName: s.database})
+	session := s.driver.NewSession(ctx, neo4j.SessionConfig{DatabaseName: s.database})
 
-    _, err := session.ExecuteRead(ctx, func(tx neo4j.ManagedTransaction) (any, error) {
-        result, err := tx.Run(ctx, "CALL db.cdc.query($from, $selectors)", map[string]any{
-            "from":      s.from(),
-            "selectors": s.selectors,
-        })
-        if err != nil {
-            return "", err
-        }
+	current, err := s.currentChangeID(ctx)
+	if err != nil {
+		return err
+	}
+	_, err = session.ExecuteRead(ctx, func(tx neo4j.ManagedTransaction) (any, error) {
+		result, err := tx.Run(ctx, "CALL cdc.query($from, $selectors)", map[string]any{
+			"from":      s.from(),
+			"selectors": s.selectors,
+		})
+		if err != nil {
+			return "", err
+		}
 
-        var record *neo4j.Record
-        for result.NextRecord(ctx, &record) {
-            err := applyChange(record) // <3>
-            if err != nil {
-                return "", fmt.Errorf("error processing record: %w", err)
-            }
+		var record *neo4j.Record
+		if !result.Peek(ctx) {
+			s.setFrom(current) // <3>
+		} else {
+			for result.NextRecord(ctx, &record) {
+				err := applyChange(record) // <4>
+				if err != nil {
+					return "", fmt.Errorf("error processing record: %w", err)
+				}
 
-            id, isNil, err := neo4j.GetRecordValue[string](record, "id")
-            if err != nil || isNil {
-                return "", fmt.Errorf("missing or invalid id value returned")
-            }
-            s.setFrom(id) // <4>
-        }
+				id, isNil, err := neo4j.GetRecordValue[string](record, "id")
+				if err != nil || isNil {
+					return "", fmt.Errorf("missing or invalid id value returned")
+				}
+				s.setFrom(id) // <5>
+			}
+		}
 
-        return s.from(), nil
-    })
-    if err != nil {
-        return fmt.Errorf("unable to query/process changes: %w", err)
-    }
+		return s.from(), nil
+	})
+	if err != nil {
+		return fmt.Errorf("unable to query/process changes: %w", err)
+	}
 
-    return nil
+	return nil
 }
 
-func (s *CDCService) earliestChangeID(ctx context.Context) (string, error) { // <5>
-    return queryChangeID(ctx, s.driver, s.database, "CALL db.cdc.earliest()")
+func (s *CDCService) earliestChangeID(ctx context.Context) (string, error) { // <6>
+	return queryChangeID(ctx, s.driver, s.database, "CALL cdc.earliest()")
 }
 
-func (s *CDCService) currentChangeID(ctx context.Context) (string, error) { // <6>
-    return queryChangeID(ctx, s.driver, s.database, "CALL db.cdc.current()")
+func (s *CDCService) currentChangeID(ctx context.Context) (string, error) { // <7>
+	return queryChangeID(ctx, s.driver, s.database, "CALL cdc.current()")
 }
 
 func (s *CDCService) from() string {
-    return *s.cursor.Load()
+	return *s.cursor.Load()
 }
 
 func (s *CDCService) setFrom(from string) {
-    s.cursor.Store(&from)
+	s.cursor.Store(&from)
 }
 
 func (s *CDCService) Start(ctx context.Context) error {
-    if s.from() == "" {
-        current, err := s.currentChangeID(ctx)
-        if err != nil {
-            return err
-        }
-        s.setFrom(current)
-    }
+	if s.from() == "" {
+		current, err := s.currentChangeID(ctx)
+		if err != nil {
+			return err
+		}
+		s.setFrom(current)
+	}
 
-    s.waitGroup.Add(1)
-    go func(ctx context.Context) {
-        defer func() {
-            s.waitGroup.Done()
-        }()
+	s.waitGroup.Add(1)
+	go func(ctx context.Context) {
+		defer func() {
+			s.waitGroup.Done()
+		}()
 
-        timer := time.NewTimer(0 * time.Millisecond)
-        for {
-            select {
-            case <-ctx.Done():
-                return
-            case <-timer.C:
-                {
-                    err := s.queryChanges(ctx)
-                    if err != nil {
-                        log.Printf("error querying/processing changes: %v", err)
-                        return
-                    }
+		timer := time.NewTimer(0 * time.Millisecond)
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-timer.C:
+				{
+					err := s.queryChanges(ctx)
+					if err != nil {
+						log.Printf("error querying/processing changes: %v", err)
+						return
+					}
 
-                    timer.Reset(500 * time.Millisecond) // <7>
-                }
-            }
-        }
-    }(ctx)
+					timer.Reset(500 * time.Millisecond) // <8>
+				}
+			}
+		}
+	}(ctx)
 
-    return nil
+	return nil
 }
 
 func (s *CDCService) WaitForExit() {
-    s.waitGroup.Wait()
+	s.waitGroup.Wait()
 }
 
 func NewCDCService(uri string, username string, password string, database string, from string, selectors []any) (*CDCService, error) {
-    driver, err := neo4j.NewDriverWithContext(uri, neo4j.BasicAuth(username, password, ""))
-    if err != nil {
-        return nil, fmt.Errorf("unable to create driver: %w", err)
-    }
+	driver, err := neo4j.NewDriverWithContext(uri, neo4j.BasicAuth(username, password, ""))
+	if err != nil {
+		return nil, fmt.Errorf("unable to create driver: %w", err)
+	}
 
-    cdc := &CDCService{
-        driver:    driver,
-        database:  database,
-        waitGroup: sync.WaitGroup{},
-        cursor:    atomic.Pointer[string]{},
-        selectors: selectors,
-    }
-    cdc.setFrom(from)
+	cdc := &CDCService{
+		driver:    driver,
+		database:  database,
+		waitGroup: sync.WaitGroup{},
+		cursor:    atomic.Pointer[string]{},
+		selectors: selectors,
+	}
+	cdc.setFrom(from)
 
-    return cdc, nil
+	return cdc, nil
 }
 
 var (
-    address  string
-    database string
-    username string
-    password string
-    from     string
+	address  string
+	database string
+	username string
+	password string
+	from     string
 )
 
 func main() {
-    rootCmd := &cobra.Command{
-        Run: func(cmd *cobra.Command, args []string) {
-            ctx, _ := signal.NotifyContext(context.Background(), os.Interrupt)
+	rootCmd := &cobra.Command{
+		Run: func(cmd *cobra.Command, args []string) {
+			ctx, _ := signal.NotifyContext(context.Background(), os.Interrupt)
 
-            selectors := []any{
-                //map[string]any{"select": "n", "labels": []string{"Person", "Employee"}}, // <8>
-            }
+			selectors := []any{
+				//map[string]any{"select": "n", "labels": []string{"Person", "Employee"}}, // <9>
+			}
 
-            cdc, err := NewCDCService(address, username, password, database, from, selectors)
-            if err != nil {
-                log.Fatal(err)
-            }
+			cdc, err := NewCDCService(address, username, password, database, from, selectors)
+			if err != nil {
+				log.Fatal(err)
+			}
 
-            if err := cdc.Start(ctx); err != nil {
-                log.Fatal(err)
-            }
+			if err := cdc.Start(ctx); err != nil {
+				log.Fatal(err)
+			}
 
-            fmt.Printf("starting...\n")
-            cdc.WaitForExit()
-            fmt.Printf("quitting...\n")
-        },
-    }
+			fmt.Printf("starting...\n")
+			cdc.WaitForExit()
+			fmt.Printf("quitting...\n")
+		},
+	}
 
-    rootCmd.Flags().StringVarP(&address, "address", "a", "bolt://localhost:7687", "Bolt URI")
-    rootCmd.Flags().StringVarP(&database, "database", "d", "", "Database")
-    rootCmd.Flags().StringVarP(&username, "username", "u", "neo4j", "Username")
-    rootCmd.Flags().StringVarP(&password, "password", "p", "passw0rd", "Password")
-    rootCmd.Flags().StringVarP(&from, "from", "f", "", "Change identifier to query changes from")
+	rootCmd.Flags().StringVarP(&address, "address", "a", "bolt://localhost:7687", "Bolt URI")
+	rootCmd.Flags().StringVarP(&database, "database", "d", "", "Database")
+	rootCmd.Flags().StringVarP(&username, "username", "u", "neo4j", "Username")
+	rootCmd.Flags().StringVarP(&password, "password", "p", "passw0rd", "Password")
+	rootCmd.Flags().StringVarP(&from, "from", "f", "", "Change identifier to query changes from")
 
-    cobra.CheckErr(rootCmd.Execute())
+	cobra.CheckErr(rootCmd.Execute())
 }
+
 ----
 
-<1> This function is called once for each change event. It should be replaced based on your use case.
+<1> This method is called once for each change.
 <2> This function fetches the changes from the database.
-<3> Here we call a function once for each change.
-<4> Note that `ExecuteRead` may retry failing queries. In order to avoid seeing the same change twice, we update the cursor as we apply the changes.
-<5> Use this function to get the earliest available change id.
-<6> Use this function to get the current change id.
-<7> Here we reset the timer so that `queryChanges` gets called repeatedly.
-<8> Here you can use a filter to receive only the changes you are interested in. The out-commented line would select only node changes that has both `Person` and `Employee` labels.
+<3> The cursor is moved forward to keep it up-to-date. 
+This may not be necessary in your use case. 
+See xref:getting-started/key-considerations.adoc#cursor-management[Cursor Management] for details.
+<4> A function is called once for each change.
+<5> Note that `ExecuteRead` may retry failing queries. 
+To avoid seeing the same change twice, update the cursor as the changes are applied.
+<6> Use this function to get the earliest available change id.
+<7> Use this function to get the current change id.
+<8> The timer is reset so that `queryChanges` gets called repeatedly.
+<9> The results may be filtered to return a subset of changes.
+The out-commented line would select only node changes that have both `Person` and `Employee` labels.

--- a/modules/ROOT/pages/examples/java.adoc
+++ b/modules/ROOT/pages/examples/java.adoc
@@ -52,21 +52,27 @@ class CDCService implements Closeable {
 
     private synchronized void queryChanges() { // <2>
         try (var session = driver.session(SessionConfig.forDatabase(database))) {
+            var current = currentChangeID();
             session.executeRead(tx -> {
-                var result = tx.run(new Query("CALL db.cdc.query($from, $selectors)", Map.of("from", cursor, "selectors", selectors)));
-                while (result.hasNext()) {
-                    var change = result.next();
-                    applyChange(change); // <3>
-                    cursor.set(change.get("id").asString()); // <4>
+                var result = tx.run(new Query("CALL db.cdc.query($from, $selectors)", Map.of("from", cursor.get(), "selectors", selectors)));
+                if (!result.hasNext()) {
+                    cursor.set(current); // <3>
+                } else {
+                    while (result.hasNext()) {
+                        var change = result.next();
+                        applyChange(change); // <4>
+                        cursor.set(change.get("id").asString()); // <5>
+                    }
                 }
                 return cursor.get();
             });
         } catch (Exception e) {
+            System.err.println(e.getMessage());
             throw new RuntimeException("Error querying/processing changes.", e);
         }
     }
 
-    private String earliestChangeID() { // <5>
+    private String earliestChangeID() { // <6>
         try (var session = driver.session(SessionConfig.forDatabase(database))) {
             return session.executeRead(tx -> {
                 var result = tx.run(new Query("CALL db.cdc.earliest"));
@@ -75,7 +81,7 @@ class CDCService implements Closeable {
         }
     }
 
-    private String currentChangeID() { // <6>
+    private String currentChangeID() { // <7>
         try (var session = driver.session(SessionConfig.forDatabase(database))) {
             return session.executeRead(tx -> {
                 var result = tx.run(new Query("CALL db.cdc.current"));
@@ -86,7 +92,7 @@ class CDCService implements Closeable {
 
     public void start(String from) {
         cursor.set(from == null ? currentChangeID() : from);
-        scheduler.scheduleWithFixedDelay(this::queryChanges, 0, 500, TimeUnit.MILLISECONDS); // <7>
+        scheduler.scheduleWithFixedDelay(this::queryChanges, 0, 500, TimeUnit.MILLISECONDS); // <8>
         Runtime.getRuntime().addShutdownHook(new Thread(scheduler::shutdownNow));
     }
 
@@ -115,7 +121,7 @@ public class Example implements Callable<Integer> {
     public Integer call() {
 
         var cdcService = new CDCService(address, database, username, password);
-        List<Map<String, Object>> selectors = List.of( // <8>
+        List<Map<String, Object>> selectors = List.of( // <9>
 //                Map.of("select", "n")
         );
         cdcService.setSelectors(selectors);
@@ -141,11 +147,17 @@ public class Example implements Callable<Integer> {
 }
 
 ----
-<1> This method is called once for each change event. It should be replaced depending on your use case.
+<1> This method is called once for each change.
 <2> This query fetches the changes from the database.
-<3> Here we call a method once for each change.
-<4> Note that `executeRead` may retry failing queries. In order to avoid seeing the same change twice, we update the cursor as we apply the changes.
-<5> Use this function to get the earliest available change id.
-<6> Use this function to get the current change id.
-<7> Here we schedule such that `queryChanges` gets called repeatedly.
-<8> Here you can limit the returned changes. The out-commented line would select only node changes and exclude all relationship changes.
+<3> The cursor is moved forward to keep it up-to-date. 
+This may not be necessary in your use case. 
+See xref:getting-started/key-considerations.adoc#cursor-management[Cursor Management] for details.
+<4> A function is called once for each change.
+<5> Note that `executeRead` may retry failing queries.
+To avoid seeing the same change twice, update the cursor as the changes are applied.
+
+<6> Use this function to get the earliest available change id.
+<7> Use this function to get the current change id.
+<8> Schedule such that `queryChanges` gets called repeatedly.
+<9> The results may be filtered to return a subset of changes.
+The out-commented line would select only node changes and exclude all relationship changes.

--- a/modules/ROOT/pages/examples/js.adoc
+++ b/modules/ROOT/pages/examples/js.adoc
@@ -16,15 +16,20 @@ function applyChange(change) { // <1>
 async function queryChanges(driver, database, cursor, selectors) {
   const session = driver.session({database: database});
   try {
+    const current = currentChangeId(driver, database);
     await session.executeRead((tx) => {
       return tx.run('CALL db.cdc.query($from, $selectors)',
           {from: cursor, selectors: selectors}); // <2>
     })
         .then((res) => {
-          res.records.map((change) => {
-            applyChange(change); // <3>
-            cursor = change.get('id'); // <4>
-          });
+          if (res.records.length === 0) {
+            cursor = current; // <3>
+          } else {
+            res.records.map((change) => {
+              applyChange(change); // <4>
+              cursor = change.get('id'); // <5>
+            });
+          }
         });
   } catch (e) {
     console.log('Failed to apply change', e);
@@ -33,7 +38,6 @@ async function queryChanges(driver, database, cursor, selectors) {
   }
   return cursor;
 }
-
 function queryChangesLoop(driver, database, cursor, selectors) {
   setTimeout(async () => {
     cursor = await queryChanges(driver, database, cursor, selectors);
@@ -41,14 +45,14 @@ function queryChangesLoop(driver, database, cursor, selectors) {
   }, 500);
 }
 
-function earliestChangeId(driver, database) { // <5>
+function earliestChangeId(driver, database) { // <6>
   return driver.executeQuery('CALL db.cdc.earliest', {}, {database: database})
       .then((res) => {
         return res.records[0].get('id');
       });
 }
 
-function currentChangeId(driver, database) { // <6>
+function currentChangeId(driver, database) { // <7>
   return driver.executeQuery('CALL db.cdc.current', {}, {'database': database})
       .then((res) => {
         return res.records[0].get('id');
@@ -69,23 +73,30 @@ async function main() {
     cursor = await currentChangeId(driver, database);
   }
 
-  const selectors = [ // <7>
+  const selectors = [ // <8>
     // {"select":"n"}
   ];
-  queryChangesLoop(driver, database, cursor, selectors); // <8>
+  queryChangesLoop(driver, database, cursor, selectors); // <9>
 
-  // await driver.close() // <9>
+  // await driver.close() // <10>
 }
 
 main();
 
 ----
-<1> This method is called once for each change event. It should be replaced depending on your use case.
+<1> This method is called once for each change.
 <2> This query fetches the changes from the database.
-<3> Here we call a method once for each change.
-<4> Note that we update the cursor defined outside the anonymous function. `session.executeRead` might re-try the query, re-running the inner anonymous function. In order to avoid re-trying from an already applied cursor position, we need to ensure that further calls to `db.cdc.query` are executed with the new cursor value.
-<5> Use this function to get the earliest available change id.
-<6> Use this function to get the current change id.
-<7> Here you can limit the returned changes. The out-commented line would select only node changes and exclude all relationship changes.
-<8> We call `queryChanges` repeatedly, using the cursor from the previous call.
-<9> Call `driver.close()` when you want to terminate the loop.
+<3> The cursor is moved forward to keep it up-to-date. 
+This may not be necessary in your use case. 
+See xref:getting-started/key-considerations.adoc#cursor-management[Cursor Management] for details.
+<4> A function is called once for each change.
+<5> Note that the cursor defined outside the anonymous function is updated. 
+`session.executeRead` might re-try the query, re-running the inner anonymous function.
+To avoid seeing the same change twice, update the cursor as the changes are applied.
+
+<6> Use this function to get the earliest available change id.
+<7> Use this function to get the current change id.
+<8> The results may be filtered to return a subset of changes.
+The out-commented line would select only node changes and exclude all relationship changes.
+<9> Call `queryChanges` repeatedly, using the cursor from the previous call.
+<10> Call `driver.close()` when the loop should be terminated.

--- a/modules/ROOT/pages/examples/python.adoc
+++ b/modules/ROOT/pages/examples/python.adoc
@@ -28,32 +28,36 @@ class CDCService:
         print(json.dumps(record_dict, indent=2, default=repr))
 
     def query_changes_query(self, tx):
+        current = self.current_change_id()
         result = tx.run('CALL db.cdc.query($cursor, $selectors)', # <2>
                         cursor=self.cursor, selectors=self.selectors)
-        for record in result:
-            try:
-                self.apply_change(record) # <3>
-            except Exception as e:
-                print('Error whilst applying change', e)
-                break
-            self.cursor = record['id'] # <4>
+        if result.peek() == None:
+            self.cursor = current # <3>
+        else:
+            for record in result:
+                try:
+                    self.apply_change(record) # <4>
+                except Exception as e:
+                    print('Error whilst applying change', e)
+                    break
+                self.cursor = record['id'] # <5>
 
     def query_changes(self):
         with self.driver.session(database=self.database) as session:
             session.execute_read(self.query_changes_query)
 
-    def earliest_change_id(self): # <5>
+    def earliest_change_id(self): # <6>
         records, _, _ = self.driver.execute_query(
             'CALL db.cdc.earliest', database_=self.database)
         return records[0]['id']
 
-    def current_change_id(self): # <6>
+    def current_change_id(self): # <7>
         records, _, _ = self.driver.execute_query(
             'CALL db.cdc.current', database_=self.database)
         return records[0]['id']
 
     def run(self):
-        while True: # <8>
+        while True: # <9>
             self.query_changes()
             time.sleep(0.5)
 
@@ -81,7 +85,7 @@ def main(argv):
         elif opt in ('-f', '--from'):
             cursor = arg
 
-    selectors = [ # <7>
+    selectors = [ # <8>
         # {'select': 'n'}
     ]
 
@@ -97,9 +101,15 @@ if __name__ == '__main__':
 ----
 <1> This method is called once for each change event. It should be replaced depending on your use case.
 <2> This query fetches the changes from the database.
-<3> Here we call a method once for each change.
-<4> `session.execute_read` may retry `query_changes_query`, for example when there are network issues. Thus `query_changes_query` must be idempotent. We keep it idempotent by updating the cursor as we go.
-<5> Use this function to get the earliest available change id.
-<6> Use this function to get the current change id.
-<7> Here you can limit the returned changes. The out-commented line would select only node changes and exclude all relationship changes.
-<8> We call `query_changes` repeatedly, using the cursor from the previous call.
+<3> The cursor is moved forward to keep it up-to-date. 
+This may not be necessary in your use case. 
+See xref:getting-started/key-considerations.adoc#cursor-management[Cursor Management] for details.
+<4> This method is called once for each change.
+<5> `session.execute_read` may retry `query_changes_query` when there are network issues, for example.
+To avoid seeing the same change twice, update the cursor as the changes are applied.
+
+<6> Use this function to get the earliest available change id.
+<7> Use this function to get the current change id.
+<8> The results may be filtered to return a subset of changes.
+The out-commented line would select only node changes and exclude all relationship changes.
+<9> Call `query_changes` repeatedly, using the cursor from the previous call.

--- a/modules/ROOT/pages/getting-started/key-considerations.adoc
+++ b/modules/ROOT/pages/getting-started/key-considerations.adoc
@@ -40,6 +40,19 @@ The number of hours or days to keep transaction logs is highly dependent on your
 
 For more details on transaction log retention and how to configure it, see link:{neo4j-docs-base-uri}/operations-manual/{page-version}/configuration/transaction-logs/#transaction-logging-log-retention[Operations Manual -> Configuration -> Transaction Log].
 
+[[cursor-management]]
+== Cursor management and server side filtering
+The changeId returned from xref:procedures/earliest.adoc[db.cdc.earliest], xref:procedures/current.adoc[db.cdc.current] and xref:procedures/query.adoc[db.cdc.query] are valid until Neo4j performs transaction log rotation as discussed in the previous section.
+
+Usually the cursor stays valid, since each call to `db.cdc.query` updates the cursor.
+
+Very strict selectors may, however, cause `db.cdc.query` to not return any changes.
+This can in extreme cases lead to the cursor not being updated in time before transaction log rotation.
+To avoid this, the xref:examples/index.adoc[examples] in this documentation update the cursor to `db.cdc.current` if `db.cdc.query` returns empty.
+Note that `db.cdc.current` needs to be called and stored before `db.cdc.query` for this to work.
+
+Another way to avoid this issue is to use broader selectors and perform client side filtering instead.
+
 [[restore-from-backup]]
 == Backup and restore operations
 


### PR DESCRIPTION
This avoids the cursor never updating when using too strict selectors

---------
Cherry pick to main