### PR TITLE
DOCOPS-176 Add page-tabs attributes to antora.yml

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -7,6 +7,8 @@ nav:
 
 asciidoc:
   attributes:
+    page-tabs: drivers-apis@
+    page-tabs-index: 90
     theme: docs
     copyright: Neo4j Inc.
     page-pagination: true


### PR DESCRIPTION
Adds `page-tabs` and `page-tabs-index` to `antora.yml`:

```yaml
asciidoc:
  attributes:
    page-tabs: drivers-apis@
    page-tabs-index: 90
```

Places this docset in the `drivers-apis` tab of the aggregated tabbed navigation, at the
position matching its order in the Docs menu on neo4j.com/docs. The value is
soft-set with a trailing `@` so it can be overridden.

Set in `antora.yml` rather than the publish playbook so the attributes apply to every
build of this component, independent of which playbook generates the HTML. This is
safe here because this docset publishes a single version.
